### PR TITLE
コメントのフォントサイズに下限を設定 fix #86

### DIFF
--- a/client/src/components/LiveOverlay/Nico.vue
+++ b/client/src/components/LiveOverlay/Nico.vue
@@ -20,7 +20,7 @@ export default defineComponent({
   setup() {
     const baseEle = ref<HTMLDivElement>()
     const { height: baseHeight, width: baseWidth } = useElementSize(baseEle)
-    const {addComment} = useCommentRenderer(baseEle, baseHeight)
+    const { addComment } = useCommentRenderer(baseEle, baseHeight)
 
     connectTarget.addEventListener('reaction', e => {
       if (document.visibilityState === 'hidden') return

--- a/client/src/components/LiveOverlay/Nico.vue
+++ b/client/src/components/LiveOverlay/Nico.vue
@@ -6,7 +6,7 @@
 import { defineComponent, ref } from 'vue'
 import { connectTarget } from '/@/lib/connect'
 import useElementSize from '/@/use/elementSize'
-import { addComment } from './commentRenderer'
+import { useCommentRenderer } from './commentRenderer'
 import { addReaction } from './reactionRenderer'
 
 export default defineComponent({
@@ -20,6 +20,7 @@ export default defineComponent({
   setup() {
     const baseEle = ref<HTMLDivElement>()
     const { height: baseHeight, width: baseWidth } = useElementSize(baseEle)
+    const {addComment} = useCommentRenderer(baseEle, baseHeight)
 
     connectTarget.addEventListener('reaction', e => {
       if (document.visibilityState === 'hidden') return
@@ -29,7 +30,7 @@ export default defineComponent({
     connectTarget.addEventListener('comment', e => {
       if (document.visibilityState === 'hidden') return
 
-      addComment(baseEle, baseHeight, e.detail.text)
+      addComment(e.detail.text)
     })
 
     return { baseEle }

--- a/client/src/components/LiveOverlay/commentRenderer.ts
+++ b/client/src/components/LiveOverlay/commentRenderer.ts
@@ -1,14 +1,42 @@
 import { Ref } from 'vue'
 
-const CommentLines = 10
-let commentLineNow = 0
+/*
+- フォントサイズ:  画面に CommentLines 行表示できるサイズ。ただし、最低でも MinimumFontSize px
+- コメント表示位置: 上から詰める
+  - 現状、コメントはその文字長に関わらず画面内にいる間行を専有する(ニコニコでは文字列幅だけ専有している)
+*/
 
-const incrementCommentLine = () => {
-  commentLineNow++
-  if (commentLineNow === CommentLines) {
-    commentLineNow = 0
+const CommentLines = 10
+const MinimumFontSize = 20
+const LineHeight = 1.5
+
+class FlowController {
+  private countPerLine = Array(CommentLines).fill(0) // 行ごとのコメント数
+  private lineCount = CommentLines // 画面に表示される行数
+  private lineHeight = MinimumFontSize * LineHeight
+
+  updateVideoHeight(height: number) {
+    this.lineCount = Math.min(
+      Math.floor(height / (MinimumFontSize * LineHeight)),
+      CommentLines
+    )
+    this.lineHeight = height / this.lineCount
+  }
+  next(): { top: number; fontSize: number; release: () => void } {
+    const countPerLine = this.countPerLine.slice(0, this.lineCount)
+    const minCount = Math.min(...countPerLine)
+    const nextIndex = countPerLine.findIndex(o => o === minCount)
+
+    this.countPerLine[nextIndex]++
+    return {
+      top: nextIndex * this.lineHeight,
+      fontSize: this.lineHeight / LineHeight,
+      release: () => this.countPerLine[nextIndex]--
+    }
   }
 }
+
+const flowController = new FlowController()
 
 export const addComment = (
   baseEle: Ref<HTMLDivElement | undefined>,
@@ -17,22 +45,22 @@ export const addComment = (
 ): void => {
   if (!baseEle.value) return
 
-  const lineHeight = baseHeight.value / CommentLines
+  flowController.updateVideoHeight(baseHeight.value)
+  const { top, fontSize, release } = flowController.next()
 
   const $comment = document.createElement('div')
   $comment.className = 'animation-comment'
   $comment.textContent = text
-  $comment.style.top = `${commentLineNow * lineHeight}px`
-  $comment.style.fontSize = `${lineHeight}px`
+  $comment.style.top = `${top}px`
+  $comment.style.fontSize = `${fontSize}px`
 
   $comment.addEventListener(
     'animationend',
     () => {
       $comment.remove()
+      release()
     },
     { once: true }
   )
   baseEle.value.append($comment)
-
-  incrementCommentLine()
 }

--- a/client/src/components/LiveOverlay/commentRenderer.ts
+++ b/client/src/components/LiveOverlay/commentRenderer.ts
@@ -10,6 +10,11 @@ const CommentLines = 10
 const MinimumFontSize = 20
 const LineHeight = 1.5
 
+const indexOfMin = (arr: number[]): number => {
+  const minCount = Math.min(...arr)
+  return arr.findIndex(o => o === minCount)
+}
+
 export const useCommentRenderer = (
   baseEle: Ref<HTMLDivElement | undefined>,
   baseHeight: Ref<number>
@@ -28,10 +33,8 @@ export const useCommentRenderer = (
   const addComment = (text: string) => {
     if (!baseEle.value) return
 
-    // 重なるコメントが少ない行を選ぶ
-    const countPerLine = countPerLineAll.value.slice(0, lineCount.value)
-    const minCount = Math.min(...countPerLine)
-    const index = countPerLine.findIndex(o => o === minCount)
+    const linesInScreen = countPerLineAll.value.slice(0, lineCount.value)
+    const index = indexOfMin(linesInScreen)
     const top = index * lineHeight.value
 
     countPerLineAll.value[index]++


### PR DESCRIPTION
スマホのような小さな画面でもコメントが読めるサイズになります
大きな画面では今までどおりのコメントの大きさです（ニコニコを真似した）

PR出してから気が付きましたが #85 を解決しかけているので、次は85のPRを書こうとおもっています。