### PR TITLE
進行設定をクライアントで操作できないように

### DIFF
--- a/client/src/components/Admin/Settings.vue
+++ b/client/src/components/Admin/Settings.vue
@@ -1,25 +1,26 @@
 <template>
   <div>
-    <state-settings :class="$style.settings" />
+    <!-- 進行状態を変更するとDBリセットしないと直らないバグが発生するので暫定的に機能を非表示にする -->
+    <!-- <state-settings :class="$style.settings" /> -->
     <live-id-settings :class="$style.settings" />
-    <presentations-settings :class="$style.settings" />
+    <!-- <presentations-settings :class="$style.settings" /> -->
     <generate-token :class="$style.settings" />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import StateSettings from './StateSettings.vue'
+// import StateSettings from './StateSettings.vue'
 import LiveIdSettings from './LiveIdSettings.vue'
-import PresentationsSettings from './PresentationsSettings.vue'
+// import PresentationsSettings from './PresentationsSettings.vue'
 import GenerateToken from './GenerateToken.vue'
 
 export default defineComponent({
   name: 'Settings',
   components: {
-    StateSettings,
+    // StateSettings,
     LiveIdSettings,
-    PresentationsSettings,
+    // PresentationsSettings,
     GenerateToken
   }
 })


### PR DESCRIPTION
DBがリセットされていない状態で進行設定が変更されるとバグって動かなくなるので、暫定的な対応としてクライアント上で設定画面に表示されないようにした